### PR TITLE
feat: add 'version' subcommand to complement --version flag

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -108,6 +108,13 @@ program
     await themesCommand.execute(theme);
   });
 
+program
+  .command('version')
+  .description('Show version information')
+  .action(() => {
+    console.log(program.version());
+  });
+
 // Handle unhandled promise rejections
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason);

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,13 @@ program
     await vscodeCommand.execute(action);
   });
 
+program
+  .command('version')
+  .description('Show version information')
+  .action(() => {
+    console.log(program.version());
+  });
+
 // Handle unhandled promise rejections
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason);


### PR DESCRIPTION
This PR adds support for the 'fosscode version' command in addition to the existing 'fosscode --version' flag.

## Changes
- Added version subcommand to both  and 
- The command outputs the same version information as the --version flag
- Maintains consistency with other CLI subcommands

## Testing
- Users can now run both  and 
- Both commands should output the same version string